### PR TITLE
idlelib: improve Go To Line dialog

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -681,10 +681,14 @@ class EditorWindow:
 
     def goto_line_event(self, event):
         text = self.text
+        num_lines = int(text.index('end').split('.')[0]) - 1
+        current_line = int(text.index('insert').split('.')[0])
         lineno = query.Goto(
                 text, "Go To Line",
-                "Enter a positive integer\n"
-                "('big' = end of file):"
+                f"Current line: {current_line}\n"
+                f"Enter a line number (1 to {num_lines}"
+                f" or -{num_lines} to -1):",
+                num_lines
                 ).result
         if lineno is not None:
             text.tag_remove("sel", "1.0", "end")

--- a/Lib/idlelib/idle_test/test_query.py
+++ b/Lib/idlelib/idle_test/test_query.py
@@ -146,6 +146,7 @@ class GotoTest(unittest.TestCase):
 
     class Dummy_ModuleName:
         entry_ok = query.Goto.entry_ok  # Function being tested.
+        num_lines = 100
         def __init__(self, dummy_entry):
             self.entry = Var(value=dummy_entry)
             self.entry_error = {'text': ''}
@@ -157,15 +158,40 @@ class GotoTest(unittest.TestCase):
         self.assertEqual(dialog.entry_ok(), None)
         self.assertIn('not a base 10 integer', dialog.entry_error['text'])
 
-    def test_bad_goto(self):
+    def test_bad_goto_zero(self):
         dialog = self.Dummy_ModuleName('0')
         self.assertEqual(dialog.entry_ok(), None)
-        self.assertIn('not a positive integer', dialog.entry_error['text'])
+        self.assertIn('0 is not a valid line number', dialog.entry_error['text'])
+
+    def test_bad_goto_too_large(self):
+        dialog = self.Dummy_ModuleName('101')
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Enter a number between 1 and 100, inclusive',
+                      dialog.entry_error['text'])
+
+    def test_bad_goto_too_negative(self):
+        dialog = self.Dummy_ModuleName('-101')
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Negative entries must be between -100 and -1, inclusive',
+                      dialog.entry_error['text'])
 
     def test_good_goto(self):
         dialog = self.Dummy_ModuleName('1')
         self.assertEqual(dialog.entry_ok(), 1)
         self.assertEqual(dialog.entry_error['text'], '')
+
+    def test_good_goto_last_line(self):
+        dialog = self.Dummy_ModuleName('100')
+        self.assertEqual(dialog.entry_ok(), 100)
+
+    def test_good_goto_negative(self):
+        # -1 should go to the last line (100), -2 to 99, etc.
+        dialog = self.Dummy_ModuleName('-1')
+        self.assertEqual(dialog.entry_ok(), 100)
+        dialog = self.Dummy_ModuleName('-2')
+        self.assertEqual(dialog.entry_ok(), 99)
+        dialog = self.Dummy_ModuleName('-100')
+        self.assertEqual(dialog.entry_ok(), 1)
 
 
 # 3 HelpSource test classes each test one method.
@@ -402,7 +428,7 @@ class GotoGuiTest(unittest.TestCase):
     def test_click_module_name(self):
         root = Tk()
         root.withdraw()
-        dialog =  query.Goto(root, 'T', 't', _utest=True)
+        dialog = query.Goto(root, 'T', 't', 100, _utest=True)
         dialog.entry.insert(0, '22')
         dialog.button_ok.invoke()
         self.assertEqual(dialog.result, 22)

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -227,19 +227,38 @@ class ModuleName(Query):
 
 
 class Goto(Query):
-    "Get a positive line number for editor Go To Line."
+    "Get a line number for editor Go To Line."
     # Used in editor.EditorWindow.goto_line_event.
 
+    def __init__(self, parent, title, message, num_lines,
+                 *, _htest=False, _utest=False):
+        self.num_lines = num_lines
+        super().__init__(parent, title, message,
+                         _htest=_htest, _utest=_utest)
+
     def entry_ok(self):
+        "Return a valid line number (converting negatives) or None."
         try:
             lineno = int(self.entry.get())
         except ValueError:
             self.showerror('not a base 10 integer.')
             return None
-        if lineno <= 0:
-            self.showerror('not a positive integer.')
+        if lineno == 0:
+            self.showerror('0 is not a valid line number.')
             return None
-        return lineno
+        if lineno > 0:
+            if lineno > self.num_lines:
+                self.showerror(
+                    f'Enter a number between 1 and {self.num_lines}, inclusive.')
+                return None
+            return lineno
+        else:  # negative: -1 means last line, -2 second to last, etc.
+            if lineno < -self.num_lines:
+                self.showerror(
+                    f'Negative entries must be between -{self.num_lines}'
+                    f' and -1, inclusive.')
+                return None
+            return self.num_lines + lineno + 1
 
 
 class HelpSource(Query):


### PR DESCRIPTION
## Summary
- Shows the user's current line number when the Go To Line popup opens
- Updates the popup label to display the valid input range (1 to N or -N to -1)
- Adds support for negative line numbers as reverse indexes (-1 = last line, -2 = second to last, etc.)
- Displays red error messages for out-of-range entries (positive or negative)

Closes #3

## Test plan
- [ ] Open IDLE and use Format → Go To Line (or keyboard shortcut)
- [ ] Verify current line number is shown in the popup
- [ ] Verify the valid range is shown in the popup label
- [ ] Enter a number larger than the total lines — confirm red error message
- [ ] Enter a negative number (e.g. `-1`) — confirm it navigates to the last line
- [ ] Enter an out-of-range negative (e.g. `-9999`) — confirm red error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)