### PR TITLE
idlelib: improve Go To Line dialog

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -681,10 +681,14 @@ class EditorWindow:
 
     def goto_line_event(self, event):
         text = self.text
+        num_lines = int(text.index('end').split('.')[0]) - 1
+        current_line = int(text.index('insert').split('.')[0])
         lineno = query.Goto(
                 text, "Go To Line",
-                "Enter a positive integer\n"
-                "('big' = end of file):"
+                f"Current line: {current_line}\n"
+                f"Enter a line number (1 to {num_lines}"
+                f" or -{num_lines} to -1):",
+                num_lines
                 ).result
         if lineno is not None:
             text.tag_remove("sel", "1.0", "end")

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -227,19 +227,38 @@ class ModuleName(Query):
 
 
 class Goto(Query):
-    "Get a positive line number for editor Go To Line."
+    "Get a line number for editor Go To Line."
     # Used in editor.EditorWindow.goto_line_event.
 
+    def __init__(self, parent, title, message, num_lines,
+                 *, _htest=False, _utest=False):
+        self.num_lines = num_lines
+        super().__init__(parent, title, message,
+                         _htest=_htest, _utest=_utest)
+
     def entry_ok(self):
+        "Return a valid line number (converting negatives) or None."
         try:
             lineno = int(self.entry.get())
         except ValueError:
             self.showerror('not a base 10 integer.')
             return None
-        if lineno <= 0:
-            self.showerror('not a positive integer.')
+        if lineno == 0:
+            self.showerror('0 is not a valid line number.')
             return None
-        return lineno
+        if lineno > 0:
+            if lineno > self.num_lines:
+                self.showerror(
+                    f'Enter a number between 1 and {self.num_lines}, inclusive.')
+                return None
+            return lineno
+        else:  # negative: -1 means last line, -2 second to last, etc.
+            if lineno < -self.num_lines:
+                self.showerror(
+                    f'Negative entries must be between -{self.num_lines}'
+                    f' and -1, inclusive.')
+                return None
+            return self.num_lines + lineno + 1
 
 
 class HelpSource(Query):


### PR DESCRIPTION
## Summary
- Shows the user's current line number when the Go To Line popup opens
- Updates the popup label to display the valid input range (1 to N or -N to -1)
- Adds support for negative line numbers as reverse indexes (-1 = last line, -2 = second to last, etc.)
- Displays red error messages for out-of-range entries (positive or negative)

Closes #3

## Test plan
- [ ] Open IDLE and use Format → Go To Line (or keyboard shortcut)
- [ ] Verify current line number is shown in the popup
- [ ] Verify the valid range is shown in the popup label
- [ ] Enter a number larger than the total lines — confirm red error message
- [ ] Enter a negative number (e.g. `-1`) — confirm it navigates to the last line
- [ ] Enter an out-of-range negative (e.g. `-9999`) — confirm red error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)