### PR TITLE
idlelib: improve Go To Line dialog

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -681,10 +681,12 @@ class EditorWindow:
 
     def goto_line_event(self, event):
         text = self.text
+        line_count = int(text.index('end-1c').split('.')[0])
+        current_line = int(text.index('insert').split('.')[0])
         lineno = query.Goto(
                 text, "Go To Line",
-                "Enter a positive integer\n"
-                "('big' = end of file):"
+                line_count=line_count,
+                current_line=current_line,
                 ).result
         if lineno is not None:
             text.tag_remove("sel", "1.0", "end")

--- a/Lib/idlelib/idle_test/test_query.py
+++ b/Lib/idlelib/idle_test/test_query.py
@@ -144,28 +144,48 @@ class ModuleNameTest(unittest.TestCase):
 class GotoTest(unittest.TestCase):
     "Test Goto subclass of Query."
 
-    class Dummy_ModuleName:
+    class Dummy_Goto:
         entry_ok = query.Goto.entry_ok  # Function being tested.
-        def __init__(self, dummy_entry):
+        def __init__(self, dummy_entry, line_count=100):
+            self.line_count = line_count
             self.entry = Var(value=dummy_entry)
             self.entry_error = {'text': ''}
         def showerror(self, message):
             self.entry_error['text'] = message
 
     def test_bogus_goto(self):
-        dialog = self.Dummy_ModuleName('a')
+        dialog = self.Dummy_Goto('a')
         self.assertEqual(dialog.entry_ok(), None)
         self.assertIn('not a base 10 integer', dialog.entry_error['text'])
 
-    def test_bad_goto(self):
-        dialog = self.Dummy_ModuleName('0')
+    def test_zero_goto(self):
+        dialog = self.Dummy_Goto('0')
         self.assertEqual(dialog.entry_ok(), None)
-        self.assertIn('not a positive integer', dialog.entry_error['text'])
+        self.assertIn('Enter a number between 1 and', dialog.entry_error['text'])
+
+    def test_too_large_goto(self):
+        dialog = self.Dummy_Goto('101', line_count=100)
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Enter a number between 1 and 100', dialog.entry_error['text'])
 
     def test_good_goto(self):
-        dialog = self.Dummy_ModuleName('1')
+        dialog = self.Dummy_Goto('1')
         self.assertEqual(dialog.entry_ok(), 1)
         self.assertEqual(dialog.entry_error['text'], '')
+
+    def test_negative_goto(self):
+        dialog = self.Dummy_Goto('-1', line_count=100)
+        self.assertEqual(dialog.entry_ok(), 100)
+
+    def test_negative_goto_middle(self):
+        dialog = self.Dummy_Goto('-2', line_count=100)
+        self.assertEqual(dialog.entry_ok(), 99)
+
+    def test_too_negative_goto(self):
+        dialog = self.Dummy_Goto('-101', line_count=100)
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Negative entries must be between -100 and -1',
+                      dialog.entry_error['text'])
 
 
 # 3 HelpSource test classes each test one method.
@@ -402,7 +422,8 @@ class GotoGuiTest(unittest.TestCase):
     def test_click_module_name(self):
         root = Tk()
         root.withdraw()
-        dialog =  query.Goto(root, 'T', 't', _utest=True)
+        dialog = query.Goto(root, 'T', line_count=100, current_line=1,
+                            _utest=True)
         dialog.entry.insert(0, '22')
         dialog.button_ok.invoke()
         self.assertEqual(dialog.result, 22)

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -227,18 +227,33 @@ class ModuleName(Query):
 
 
 class Goto(Query):
-    "Get a positive line number for editor Go To Line."
+    "Get a line number for editor Go To Line."
     # Used in editor.EditorWindow.goto_line_event.
 
+    def __init__(self, parent, title, *, line_count, current_line,
+                 _htest=False, _utest=False):
+        self.line_count = line_count
+        message = (f"Current line: {current_line}\n"
+                   f"Enter a line number (1 to {line_count}"
+                   f" or -{line_count} to -1):")
+        super().__init__(parent, title, message, _htest=_htest, _utest=_utest)
+
     def entry_ok(self):
+        n = self.line_count
         try:
             lineno = int(self.entry.get())
         except ValueError:
             self.showerror('not a base 10 integer.')
             return None
-        if lineno <= 0:
-            self.showerror('not a positive integer.')
+        if lineno == 0 or lineno > n:
+            self.showerror(f'Enter a number between 1 and {n}, inclusive.')
             return None
+        if lineno < -n:
+            self.showerror(
+                f'Negative entries must be between -{n} and -1, inclusive.')
+            return None
+        if lineno < 0:
+            lineno = n + lineno + 1
         return lineno
 
 


### PR DESCRIPTION
Closes #3

## Summary
- Shows the user's current line number when the Go To Line popup opens
- Displays the valid input range (1 to N or -N to -1) in the prompt
- Out-of-range positive entries show a red error: *"Enter a number between 1 and N, inclusive"*
- Supports negative indexing: `-1` → last line, `-2` → second to last, etc.; invalid negatives show *"Negative entries must be between -N and -1, inclusive"*
- Unit tests updated to cover all new validation cases and negative indexing

## Test plan
- [ ] Open IDLE and trigger Go To Line (Edit → Go to Line)
- [ ] Verify current line number and valid range are displayed in the dialog
- [ ] Enter a number larger than the file's line count — confirm red error message
- [ ] Enter `0` — confirm red error message
- [ ] Enter `-1` — confirm navigation to last line
- [ ] Enter a too-negative number — confirm red error message
- [ ] Enter a valid positive number — confirm navigation works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)