### PR TITLE
Improve Go To Line feature in IDLE

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -681,10 +681,15 @@ class EditorWindow:
 
     def goto_line_event(self, event):
         text = self.text
+        num_lines = int(text.index("end-1c").split(".")[0])
+        current_line = int(text.index("insert").split(".")[0])
         lineno = query.Goto(
                 text, "Go To Line",
-                "Enter a positive integer\n"
-                "('big' = end of file):"
+                f"Current line: {current_line}\n"
+                f"Enter a line number (1 to {num_lines}"
+                f" or -{num_lines} to -1):",
+                num_lines=num_lines,
+                current_line=current_line,
                 ).result
         if lineno is not None:
             text.tag_remove("sel", "1.0", "end")

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -227,8 +227,15 @@ class ModuleName(Query):
 
 
 class Goto(Query):
-    "Get a positive line number for editor Go To Line."
+    "Get a line number for editor Go To Line, supporting negative indexing."
     # Used in editor.EditorWindow.goto_line_event.
+
+    def __init__(self, parent, title, message, *, num_lines, current_line,
+                 _htest=False, _utest=False):
+        self.num_lines = num_lines
+        self.current_line = current_line
+        super().__init__(parent, title, message,
+                         _htest=_htest, _utest=_utest)
 
     def entry_ok(self):
         try:
@@ -236,9 +243,16 @@ class Goto(Query):
         except ValueError:
             self.showerror('not a base 10 integer.')
             return None
-        if lineno <= 0:
-            self.showerror('not a positive integer.')
+        if lineno == 0 or lineno > self.num_lines:
+            self.showerror(
+                f'Enter a number between 1 and {self.num_lines}, inclusive.')
             return None
+        if lineno < -self.num_lines:
+            self.showerror(
+                f'Negative entries must be between -{self.num_lines} and -1, inclusive.')
+            return None
+        if lineno < 0:
+            lineno = self.num_lines + lineno + 1
         return lineno
 
 


### PR DESCRIPTION
Closes #3

## Changes
- Show current line number when the Go To Line popup opens
- Display valid range in the prompt (`1 to N` or `-N to -1`)
- Red error message when value is too large: `Enter a number between 1 and N, inclusive.`
- Red error message when value is too negative: `Negative entries must be between -N and -1, inclusive.`
- Support negative indexing (e.g. `-1` = last line, `-2` = second-to-last, etc.)