### PR TITLE
Improve Go To Line feature in idlelib

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -681,11 +681,10 @@ class EditorWindow:
 
     def goto_line_event(self, event):
         text = self.text
+        num_lines = int(text.index('end-1c').split('.')[0])
+        current_line = int(text.index('insert').split('.')[0])
         lineno = query.Goto(
-                text, "Go To Line",
-                "Enter a positive integer\n"
-                "('big' = end of file):"
-                ).result
+                text, "Go To Line", num_lines, current_line).result
         if lineno is not None:
             text.tag_remove("sel", "1.0", "end")
             text.mark_set("insert", f'{lineno}.0')

--- a/Lib/idlelib/idle_test/test_query.py
+++ b/Lib/idlelib/idle_test/test_query.py
@@ -146,6 +146,7 @@ class GotoTest(unittest.TestCase):
 
     class Dummy_ModuleName:
         entry_ok = query.Goto.entry_ok  # Function being tested.
+        num_lines = 100
         def __init__(self, dummy_entry):
             self.entry = Var(value=dummy_entry)
             self.entry_error = {'text': ''}
@@ -157,15 +158,38 @@ class GotoTest(unittest.TestCase):
         self.assertEqual(dialog.entry_ok(), None)
         self.assertIn('not a base 10 integer', dialog.entry_error['text'])
 
-    def test_bad_goto(self):
+    def test_bad_goto_zero(self):
         dialog = self.Dummy_ModuleName('0')
         self.assertEqual(dialog.entry_ok(), None)
-        self.assertIn('not a positive integer', dialog.entry_error['text'])
+        self.assertIn('Enter a number between 1 and', dialog.entry_error['text'])
+
+    def test_bad_goto_too_large(self):
+        dialog = self.Dummy_ModuleName('101')
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Enter a number between 1 and 100, inclusive',
+                      dialog.entry_error['text'])
+
+    def test_bad_goto_too_negative(self):
+        dialog = self.Dummy_ModuleName('-101')
+        self.assertEqual(dialog.entry_ok(), None)
+        self.assertIn('Negative entries must be between -100 and -1, inclusive',
+                      dialog.entry_error['text'])
 
     def test_good_goto(self):
         dialog = self.Dummy_ModuleName('1')
         self.assertEqual(dialog.entry_ok(), 1)
         self.assertEqual(dialog.entry_error['text'], '')
+
+    def test_good_goto_last_line(self):
+        dialog = self.Dummy_ModuleName('100')
+        self.assertEqual(dialog.entry_ok(), 100)
+
+    def test_good_goto_negative(self):
+        # -1 should resolve to last line (100), -2 to 99, etc.
+        dialog = self.Dummy_ModuleName('-1')
+        self.assertEqual(dialog.entry_ok(), 100)
+        dialog = self.Dummy_ModuleName('-100')
+        self.assertEqual(dialog.entry_ok(), 1)
 
 
 # 3 HelpSource test classes each test one method.
@@ -402,7 +426,7 @@ class GotoGuiTest(unittest.TestCase):
     def test_click_module_name(self):
         root = Tk()
         root.withdraw()
-        dialog =  query.Goto(root, 'T', 't', _utest=True)
+        dialog = query.Goto(root, 'T', 100, 1, _utest=True)
         dialog.entry.insert(0, '22')
         dialog.button_ok.invoke()
         self.assertEqual(dialog.result, 22)

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -227,19 +227,40 @@ class ModuleName(Query):
 
 
 class Goto(Query):
-    "Get a positive line number for editor Go To Line."
+    "Get a line number for editor Go To Line, supporting negative indexing."
     # Used in editor.EditorWindow.goto_line_event.
 
+    def __init__(self, parent, title, num_lines, current_line,
+                 *, _htest=False, _utest=False):
+        self.num_lines = num_lines
+        self.current_line = current_line
+        message = (f"Current line: {current_line}\n"
+                   f"Enter a line number (1 to {num_lines}"
+                   f" or -{num_lines} to -1):")
+        super().__init__(parent, title, message, _htest=_htest, _utest=_utest)
+
     def entry_ok(self):
+        "Return a valid 1-based line number or None."
         try:
             lineno = int(self.entry.get())
         except ValueError:
             self.showerror('not a base 10 integer.')
             return None
-        if lineno <= 0:
-            self.showerror('not a positive integer.')
+        n = self.num_lines
+        if lineno > 0:
+            if lineno > n:
+                self.showerror(f'Enter a number between 1 and {n}, inclusive.')
+                return None
+            return lineno
+        elif lineno < 0:
+            if lineno < -n:
+                self.showerror(
+                    f'Negative entries must be between -{n} and -1, inclusive.')
+                return None
+            return n + lineno + 1
+        else:
+            self.showerror(f'Enter a number between 1 and {n}, inclusive.')
             return None
-        return lineno
 
 
 class HelpSource(Query):


### PR DESCRIPTION
## Summary
- Shows the user's current line number and valid range when the Go To Line dialog opens
- Supports negative indexing (e.g. `-1` = last line, `-2` = second to last)
- Displays specific red error messages for out-of-range or invalid input
- Updates unit tests to cover new validation logic and negative indexing

## Test plan
- [ ] Open a file in IDLE and trigger Go To Line (`Alt+G`) — verify current line and range are shown
- [ ] Enter a valid positive line number — verify navigation works
- [ ] Enter a number larger than the file's line count — verify red error message
- [ ] Enter `-1` — verify it navigates to the last line
- [ ] Enter a negative number more negative than `-N` — verify red error message
- [ ] Enter `0` — verify red error message
- [ ] Run `python -m pytest Lib/idlelib/idle_test/test_query.py -k Goto`

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)